### PR TITLE
Add skip existing query parameters support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+server-gtm-sandboxed-apis.d.ts

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "tabWidth": 2,
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# Query Replacer
+# Query Replacer Variable for GTM Server Side
 
-Query Replacer variable allows replace parameters in the URL location, use it inside server Google Tag Manager.
-
+The **Query Replacer Variable** allows to replace URL query parameters in the `page_location` Event Data parameter.
 
 ## Open Source
 
-Query Replacer Variable for GTM Server Side is developing and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.
+The **Query Replacer Variable** for GTM Server Side is developed and maintained by [Stape Team](https://stape.io/) under the Apache 2.0 license.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,5 +1,8 @@
-homepage: "https://stape.io/"
+homepage: 'https://stape.io/'
+documentation: 'https://github.com/stape-io/query-replacer-variable'
 versions:
+  - sha: 3ea7f72bbd7e7f533f20f8190556c338dae69cad
+    changeNotes: Added support for skipping existing query parameters.
   - sha: 782b9c5e5b221b3c286e3ca5379a5566fa2f5b67
     changeNotes: Code refactoring, better parsing of input string and output result. Added some tests.
   - sha: 1e7d672aac990a4f9d293b2e6d81d5e60176a7b6

--- a/template.js
+++ b/template.js
@@ -5,6 +5,7 @@ const decodeUriComponent = require('decodeUriComponent');
 const encodeUriComponent = require('encodeUriComponent');
 const parseUrl = require('parseUrl');
 const makeTableMap = require('makeTableMap');
+const getType = require('getType');
 
 /*==============================================================================
 ==============================================================================*/
@@ -18,11 +19,18 @@ const fromTo = makeTableMap(data.customParams, 'from', 'to');
 const searchParams = parsedUrl.searchParams;
 const newSearchParams = [];
 
-// 'key' is always decoded.
-for (let key in searchParams) {
-  const value = searchParams[key];
-  const newKey = decodeUriComponent(fromTo[key] || fromTo[encodeUriComponent(key)] || ''); // If the person added it either decoded or encoded.
-  newSearchParams.push(encodeUriComponent(newKey ? newKey : key) + '=' + encodeUriComponent(value));
+// 'fromKey' is always decoded.
+for (const fromKey in searchParams) {
+  const value = searchParams[fromKey];
+
+  let toKey = decodeUriComponent(fromTo[fromKey] || fromTo[enc(fromKey)] || ''); // If the person added it either decoded or encoded.
+  if (data.skipExisting && searchParams.hasOwnProperty(toKey)) toKey = undefined;
+
+  const newKey = toKey ? toKey : fromKey;
+
+  getType(value) === 'array' // For parameters that are repeated.
+    ? value.forEach((v) => newSearchParams.push(enc(newKey) + '=' + enc(v)))
+    : newSearchParams.push(enc(newKey) + '=' + enc(value));
 }
 
 return (
@@ -32,3 +40,11 @@ return (
   newSearchParams.join('&') +
   (parsedUrl.hash ? parsedUrl.hash : '')
 );
+
+/*==============================================================================
+  Helpers
+==============================================================================*/
+
+function enc(data) {
+  return encodeUriComponent(data || '');
+}

--- a/template.js
+++ b/template.js
@@ -1,8 +1,13 @@
+/// <reference path="./server-gtm-sandboxed-apis.d.ts" />
+
 const getEventData = require('getEventData');
 const decodeUriComponent = require('decodeUriComponent');
 const encodeUriComponent = require('encodeUriComponent');
 const parseUrl = require('parseUrl');
 const makeTableMap = require('makeTableMap');
+
+/*==============================================================================
+==============================================================================*/
 
 const pageLocation = getEventData('page_location');
 const parsedUrl = parseUrl(pageLocation);
@@ -10,7 +15,6 @@ const parsedUrl = parseUrl(pageLocation);
 if (!parsedUrl.search) return pageLocation;
 
 const fromTo = makeTableMap(data.customParams, 'from', 'to');
-
 const searchParams = parsedUrl.searchParams;
 const newSearchParams = [];
 
@@ -21,4 +25,10 @@ for (let key in searchParams) {
   newSearchParams.push(encodeUriComponent(newKey ? newKey : key) + '=' + encodeUriComponent(value));
 }
 
-return parsedUrl.origin + parsedUrl.pathname + '?' + newSearchParams.join('&') + (parsedUrl.hash ? parsedUrl.hash : '');
+return (
+  parsedUrl.origin +
+  parsedUrl.pathname +
+  '?' +
+  newSearchParams.join('&') +
+  (parsedUrl.hash ? parsedUrl.hash : '')
+);

--- a/template.tpl
+++ b/template.tpl
@@ -63,6 +63,21 @@ ___TEMPLATE_PARAMETERS___
         "type": "NON_EMPTY"
       }
     ]
+  },
+  {
+    "type": "GROUP",
+    "name": "moreSettingsGroup",
+    "displayName": "More Settings",
+    "groupStyle": "ZIPPY_OPEN",
+    "subParams": [
+      {
+        "type": "CHECKBOX",
+        "name": "skipExisting",
+        "checkboxText": "Skip Existing Query Parameters",
+        "simpleValueType": true,
+        "help": "If the URL already contains a parameter matching one from the \"\u003ci\u003ewith this\u003c/i\u003e\" column, the parameter specified in the \"\u003ci\u003ereplace this\u003c/i\u003e\" will not be replaced."
+      }
+    ]
   }
 ]
 
@@ -76,6 +91,7 @@ const decodeUriComponent = require('decodeUriComponent');
 const encodeUriComponent = require('encodeUriComponent');
 const parseUrl = require('parseUrl');
 const makeTableMap = require('makeTableMap');
+const getType = require('getType');
 
 /*==============================================================================
 ==============================================================================*/
@@ -89,11 +105,18 @@ const fromTo = makeTableMap(data.customParams, 'from', 'to');
 const searchParams = parsedUrl.searchParams;
 const newSearchParams = [];
 
-// 'key' is always decoded.
-for (let key in searchParams) {
-  const value = searchParams[key];
-  const newKey = decodeUriComponent(fromTo[key] || fromTo[encodeUriComponent(key)] || ''); // If the person added it either decoded or encoded.
-  newSearchParams.push(encodeUriComponent(newKey ? newKey : key) + '=' + encodeUriComponent(value));
+// 'fromKey' is always decoded.
+for (const fromKey in searchParams) {
+  const value = searchParams[fromKey];
+
+  let toKey = decodeUriComponent(fromTo[fromKey] || fromTo[enc(fromKey)] || ''); // If the person added it either decoded or encoded.
+  if (data.skipExisting && searchParams.hasOwnProperty(toKey)) toKey = undefined;
+
+  const newKey = toKey ? toKey : fromKey;
+
+  getType(value) === 'array' // For parameters that are repeated.
+    ? value.forEach((v) => newSearchParams.push(enc(newKey) + '=' + enc(v)))
+    : newSearchParams.push(enc(newKey) + '=' + enc(value));
 }
 
 return (
@@ -103,6 +126,14 @@ return (
   newSearchParams.join('&') +
   (parsedUrl.hash ? parsedUrl.hash : '')
 );
+
+/*==============================================================================
+  Helpers
+==============================================================================*/
+
+function enc(data) {
+  return encodeUriComponent(data || '');
+}
 
 
 ___SERVER_PERMISSIONS___
@@ -162,7 +193,7 @@ scenarios:
       if (key === 'page_location') return page_location_without_query_params;
     });
 
-    let variableResult = runCode(mockData);
+    const variableResult = runCode(mockData);
 
     assertThat(variableResult).isEqualTo(page_location_without_query_params);
 - name: URL with parameters and no modifications
@@ -180,9 +211,28 @@ scenarios:
       if (key === 'page_location') return page_location_with_query_params;
     });
 
-    let variableResult = runCode(mockData);
+    const variableResult = runCode(mockData);
 
-    assertThat(variableResult).isEqualTo(page_location_with_query_params);
+    assertThat(variableResult).isEqualTo('https://example.com/path/?oneparam=1%202%203%204&teste=123&anotherparam=hahsdhasd&anotherparam=repeated&par%C3%A2metro=%C3%A7%C3%A3o%3F1J23I12I3J#hash');
+- name: URL with parameters and no modifications (skipping existing query parameters)
+  code: |-
+    const decodeUriComponent = require('decodeUriComponent');
+
+    const mockData = {
+      customParams: [
+        { from: 'this', to: 'that' },
+        { from: 'foo', to: 'bar' },
+      ],
+      skipExisting: true
+    };
+
+    mock('getEventData', (key) => {
+      if (key === 'page_location') return page_location_with_query_params;
+    });
+
+    const variableResult = runCode(mockData);
+
+    assertThat(variableResult).isEqualTo('https://example.com/path/?oneparam=1%202%203%204&teste=123&anotherparam=hahsdhasd&anotherparam=repeated&par%C3%A2metro=%C3%A7%C3%A3o%3F1J23I12I3J#hash');
 - name: URL with parameters and with modifications
   code: |
     const decodeUriComponent = require('decodeUriComponent');
@@ -199,12 +249,31 @@ scenarios:
       if (key === 'page_location') return page_location_with_query_params;
     });
 
-    let variableResult = runCode(mockData);
+    const variableResult = runCode(mockData);
 
-    assertThat(variableResult).isEqualTo('https://example.com/path/?new_one_param=1%202%203%204&new_teste=123&anotherparam=hahsdhasd&test%C3%A3o=%C3%A7%C3%A3o%3F1J23I12I3J#hash');
+    assertThat(variableResult).isEqualTo('https://example.com/path/?new_one_param=1%202%203%204&new_teste=123&anotherparam=hahsdhasd&anotherparam=repeated&test%C3%A3o=%C3%A7%C3%A3o%3F1J23I12I3J#hash');
+- name: URL with parameters and with modifications (skipping existing query parameters)
+  code: |
+    const decodeUriComponent = require('decodeUriComponent');
+
+    const mockData = {
+      customParams: [
+        { from: 'oneparam', to: 'anotherparam' },
+        { from: 'teste', to: 'new_teste' }
+      ],
+      skipExisting: true
+    };
+
+    mock('getEventData', (key) => {
+      if (key === 'page_location') return page_location_with_query_params;
+    });
+
+    const variableResult = runCode(mockData);
+
+    assertThat(variableResult).isEqualTo('https://example.com/path/?oneparam=1%202%203%204&new_teste=123&anotherparam=hahsdhasd&anotherparam=repeated&par%C3%A2metro=%C3%A7%C3%A3o%3F1J23I12I3J#hash');
 setup: |-
   const page_location_without_query_params = 'https://example.com/path/#hash';
-  const page_location_with_query_params = 'https://example.com/path/?oneparam=1%202%203%204&teste=123&anotherparam=hahsdhasd&par%C3%A2metro=%C3%A7%C3%A3o%3F1J23I12I3J#hash';
+  const page_location_with_query_params = 'https://example.com/path/?oneparam=1%202%203%204&teste=123&anotherparam=hahsdhasd&par%C3%A2metro=%C3%A7%C3%A3o%3F1J23I12I3J&anotherparam=repeated#hash';
 
 
 ___NOTES___

--- a/template.tpl
+++ b/template.tpl
@@ -27,7 +27,7 @@ ___TEMPLATE_PARAMETERS___
   {
     "type": "LABEL",
     "name": "label",
-    "displayName": "Specify below which parameters in the ‘page_location’ event data should be replaced"
+    "displayName": "Specify below which parameters in the \u0027page_location\u0027 Event Data variable should be replaced."
   },
   {
     "type": "SIMPLE_TABLE",
@@ -69,11 +69,16 @@ ___TEMPLATE_PARAMETERS___
 
 ___SANDBOXED_JS_FOR_SERVER___
 
+/// <reference path="./server-gtm-sandboxed-apis.d.ts" />
+
 const getEventData = require('getEventData');
 const decodeUriComponent = require('decodeUriComponent');
 const encodeUriComponent = require('encodeUriComponent');
 const parseUrl = require('parseUrl');
 const makeTableMap = require('makeTableMap');
+
+/*==============================================================================
+==============================================================================*/
 
 const pageLocation = getEventData('page_location');
 const parsedUrl = parseUrl(pageLocation);
@@ -81,7 +86,6 @@ const parsedUrl = parseUrl(pageLocation);
 if (!parsedUrl.search) return pageLocation;
 
 const fromTo = makeTableMap(data.customParams, 'from', 'to');
-
 const searchParams = parsedUrl.searchParams;
 const newSearchParams = [];
 
@@ -92,7 +96,13 @@ for (let key in searchParams) {
   newSearchParams.push(encodeUriComponent(newKey ? newKey : key) + '=' + encodeUriComponent(value));
 }
 
-return parsedUrl.origin + parsedUrl.pathname + '?' + newSearchParams.join('&') + (parsedUrl.hash ? parsedUrl.hash : '');
+return (
+  parsedUrl.origin +
+  parsedUrl.pathname +
+  '?' +
+  newSearchParams.join('&') +
+  (parsedUrl.hash ? parsedUrl.hash : '')
+);
 
 
 ___SERVER_PERMISSIONS___


### PR DESCRIPTION
As mentioned here https://github.com/stape-io/query-replacer-variable/issues/3, if a query parameter already exists in the URL, it will be added again.

This PR adds a new checkbox that, when checked, prevents this from happening.